### PR TITLE
fix: playback 403 error

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,7 +37,7 @@ dependencies {
 
     /** Discord **/
     implementation("net.dv8tion", "JDA", Versions.JDA)
-    implementation("com.github.walkyst", "lavaplayer-fork", Versions.LAVAPLAYER)
+    implementation("dev.arbjerg", "lavaplayer", Versions.LAVAPLAYER)
 
     /** Logging **/
     implementation("ch.qos.logback", "logback-classic", Versions.LOGBACK)

--- a/buildSrc/src/main/kotlin/dev/jonaz/vured/bot/gradle/Versions.kt
+++ b/buildSrc/src/main/kotlin/dev/jonaz/vured/bot/gradle/Versions.kt
@@ -5,8 +5,8 @@ object Versions {
     const val KOTLIN_COROUTINES = "1.6.0"
 
     /** Discord **/
-    const val JDA = "5.0.0-beta.6"
-    const val LAVAPLAYER = "1.4.0"
+    const val JDA = "5.0.0-beta.13"
+    const val LAVAPLAYER = "2.0.0"
 
     /** Application **/
     const val KOIN = "3.1.5"


### PR DESCRIPTION
As YouTube implemented new player parameters, [Walkyst](https://github.com/Walkyst/lavaplayer-fork) hasn't patched his repository for this change.

I have created a [pull request](https://github.com/Walkyst/lavaplayer-fork/pull/124) for this change in his repository. Since there is a Lavaplayer maintained by Lavalink's developers with the patch already implemented, we will change the Lavaplayer dependency here.